### PR TITLE
feat: add correct filtering (similar to hazelcast)

### DIFF
--- a/src/main/java/io/zeebe/monitor/zeebe/KafkaStreamsService.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/KafkaStreamsService.java
@@ -1,5 +1,6 @@
 package io.zeebe.monitor.zeebe;
 
+import io.zeebe.exporter.proto.Schema;
 import io.zeebe.monitor.zeebe.importers.*;
 import io.zeebe.monitor.zeebe.util.BuildRecordUtil;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -7,6 +8,9 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
+
+import static io.zeebe.monitor.zeebe.util.ImportUtil.ifEvent;
+import static io.zeebe.monitor.zeebe.util.ImportUtil.isEvent;
 
 @Profile("kafka")
 @Component
@@ -40,44 +44,56 @@ public class KafkaStreamsService {
 
     @PostConstruct
     public void start() {
-        zeebeKafkaStreams.kafkaProcessStream().foreach((key, event) -> {
-            processAndElementImporter.importProcess(BuildRecordUtil.buildProcessRecord(event));
-        });
 
-        zeebeKafkaStreams.kafkaProcessInstanceStream().foreach((key, event) -> {
-                processAndElementImporter.importProcessInstance(BuildRecordUtil.buildProcessInstanceRecord(event));
-        });
+        zeebeKafkaStreams
+            .kafkaProcessStream()
+            .mapValues((key, event) -> BuildRecordUtil.buildProcessRecord(event))
+            .filter((key, record) -> ifEvent(record, Schema.ProcessRecord::getMetadata))
+            .foreach((key, record) -> processAndElementImporter.importProcess(record));
 
-        zeebeKafkaStreams.kafkaZeebeTimerStream().foreach((key, event) -> {
-                timerImporter.importTimer(BuildRecordUtil.buildTimerRecord(event));
-        });
+        zeebeKafkaStreams.kafkaProcessInstanceStream()
+            .mapValues((key, event) -> BuildRecordUtil.buildProcessInstanceRecord(event))
+            .filter((key, record) -> ifEvent(record, Schema.ProcessInstanceRecord::getMetadata))
+            .foreach((key, record) -> processAndElementImporter.importProcessInstance(record));
 
-        zeebeKafkaStreams.kafkaZeebeVariableStream().foreach((key, event) -> {
-                variableImporter.importVariable(BuildRecordUtil.buildVariableRecord(event));
-        });
+        zeebeKafkaStreams.kafkaZeebeTimerStream()
+            .mapValues((key, event) -> BuildRecordUtil.buildTimerRecord(event))
+            .filter((key, record) -> ifEvent(record, Schema.TimerRecord::getMetadata))
+            .foreach((key, record) -> timerImporter.importTimer(record));
 
-        zeebeKafkaStreams.kafkaZeebeErrorStream().foreach((key, event) -> {
-            errorImporter.importError(BuildRecordUtil.buildErrorRecord(event));
-        });
+        zeebeKafkaStreams.kafkaZeebeVariableStream()
+            .mapValues((key, event) -> BuildRecordUtil.buildVariableRecord(event))
+            .filter((key, record) -> ifEvent(record, Schema.VariableRecord::getMetadata))
+            .foreach((key, record) -> variableImporter.importVariable(record));
 
-        zeebeKafkaStreams.kafkaZeebeMessageStream().foreach((key, event) -> {
-            messageImporter.importMessage(BuildRecordUtil.buildMessageRecord(event));
-        });
+        zeebeKafkaStreams.kafkaZeebeErrorStream()
+            .mapValues((key, event) -> BuildRecordUtil.buildErrorRecord(event))
+            .filter((key, record) -> ifEvent(record, Schema.ErrorRecord::getMetadata))
+            .foreach((key, record) -> errorImporter.importError(record));
 
-        zeebeKafkaStreams.kafkaZeebeIncidentStream().foreach((key, event) -> {
-            incidentImporter.importIncident(BuildRecordUtil.buildIncidentRecord(event));
-        });
+        zeebeKafkaStreams.kafkaZeebeMessageStream()
+            .mapValues((key, event) -> BuildRecordUtil.buildMessageRecord(event))
+            .filter((key, record) -> ifEvent(record, Schema.MessageRecord::getMetadata))
+            .foreach((key, record) -> messageImporter.importMessage(record));
 
-        zeebeKafkaStreams.kafkaZeebeMessageSubscriptionStream().foreach((key, event) -> {
-                messageSubscriptionImporter.importMessageSubscription(BuildRecordUtil.buildMessageSubscriptionRecord(event));
-        });
+        zeebeKafkaStreams.kafkaZeebeIncidentStream()
+            .mapValues((key, event) -> BuildRecordUtil.buildIncidentRecord(event))
+            .filter((key, record) -> ifEvent(record, Schema.IncidentRecord::getMetadata))
+            .foreach((key, record) -> incidentImporter.importIncident(record));
 
-        zeebeKafkaStreams.kafkaZeebeMessageSubscriptionStartEventStream().foreach((key, event) -> {
-            messageSubscriptionImporter.importMessageStartEventSubscription(BuildRecordUtil.buildMessageStartEventSubscriptionRecord(event));
-        });
+        zeebeKafkaStreams.kafkaZeebeMessageSubscriptionStream()
+            .mapValues((key, event) -> BuildRecordUtil.buildMessageSubscriptionRecord(event))
+            .filter((key, record) -> ifEvent(record, Schema.MessageSubscriptionRecord::getMetadata))
+            .foreach((key, record) -> messageSubscriptionImporter.importMessageSubscription(record));
 
-        zeebeKafkaStreams.kafkaZeebeJobStream().foreach((key, event) -> {
-                jobImporter.importJob(BuildRecordUtil.buildJobRecord(event));
-        });
+        zeebeKafkaStreams.kafkaZeebeMessageSubscriptionStartEventStream()
+            .mapValues((key, event) -> BuildRecordUtil.buildMessageStartEventSubscriptionRecord(event))
+            .filter((key, record) -> ifEvent(record, Schema.MessageStartEventSubscriptionRecord::getMetadata))
+            .foreach((key, record) -> messageSubscriptionImporter.importMessageStartEventSubscription(record));
+
+        zeebeKafkaStreams.kafkaZeebeJobStream()
+            .mapValues((key, event) -> BuildRecordUtil.buildJobRecord(event))
+            .filter((key, record) -> ifEvent(record, Schema.JobRecord::getMetadata))
+            .foreach((key, record) -> jobImporter.importJob(record));
     }
 }

--- a/src/main/java/io/zeebe/monitor/zeebe/KafkaStreamsService.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/KafkaStreamsService.java
@@ -1,7 +1,14 @@
 package io.zeebe.monitor.zeebe;
 
 import io.zeebe.exporter.proto.Schema;
-import io.zeebe.monitor.zeebe.importers.*;
+import io.zeebe.monitor.zeebe.importers.ErrorImporter;
+import io.zeebe.monitor.zeebe.importers.IncidentImporter;
+import io.zeebe.monitor.zeebe.importers.JobImporter;
+import io.zeebe.monitor.zeebe.importers.MessageImporter;
+import io.zeebe.monitor.zeebe.importers.MessageSubscriptionImporter;
+import io.zeebe.monitor.zeebe.importers.ProcessAndElementImporter;
+import io.zeebe.monitor.zeebe.importers.TimerImporter;
+import io.zeebe.monitor.zeebe.importers.VariableImporter;
 import io.zeebe.monitor.zeebe.util.BuildRecordUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
@@ -10,7 +17,6 @@ import org.springframework.stereotype.Component;
 import javax.annotation.PostConstruct;
 
 import static io.zeebe.monitor.zeebe.util.ImportUtil.ifEvent;
-import static io.zeebe.monitor.zeebe.util.ImportUtil.isEvent;
 
 @Profile("kafka")
 @Component

--- a/src/main/java/io/zeebe/monitor/zeebe/ZeebeImportService.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/ZeebeImportService.java
@@ -13,6 +13,8 @@ import org.springframework.stereotype.Component;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import static io.zeebe.monitor.zeebe.util.ImportUtil.ifEvent;
+
 @Profile("hazelcast")
 @Component
 public class ZeebeImportService {
@@ -87,20 +89,6 @@ public class ZeebeImportService {
     }
 
     return builder.build();
-  }
-
-  private <T> void ifEvent(
-      final T record,
-      final Function<T, Schema.RecordMetadata> extractor,
-      final Consumer<T> consumer) {
-    final var metadata = extractor.apply(record);
-    if (isEvent(metadata)) {
-      consumer.accept(record);
-    }
-  }
-
-  private boolean isEvent(final Schema.RecordMetadata metadata) {
-    return metadata.getRecordType() == Schema.RecordMetadata.RecordType.EVENT;
   }
 
 }

--- a/src/main/java/io/zeebe/monitor/zeebe/util/ImportUtil.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/util/ImportUtil.java
@@ -1,0 +1,27 @@
+package io.zeebe.monitor.zeebe.util;
+
+import io.zeebe.exporter.proto.Schema;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class ImportUtil {
+  public static <T> void ifEvent(
+      final T record,
+      final Function<T, Schema.RecordMetadata> extractor,
+      final Consumer<T> consumer) {
+    final var metadata = extractor.apply(record);
+    if (isEvent(metadata)) {
+      consumer.accept(record);
+    }
+  }
+  public static <T> boolean ifEvent(
+      final T record,
+      final Function<T, Schema.RecordMetadata> extractor) {
+    final var metadata = extractor.apply(record);
+    return isEvent(metadata);
+  }
+  public static boolean isEvent(final Schema.RecordMetadata metadata) {
+    return metadata.getRecordType() == Schema.RecordMetadata.RecordType.EVENT;
+  }
+}


### PR DESCRIPTION
These filters were previously when importing from Hazelcast, added them to Kafka import as well. 
```
.addMessageStartEventSubscriptionListener(
                record ->
                    ifEvent(
                        record,
                        Schema.MessageStartEventSubscriptionRecord::getMetadata,
                            messageSubscriptionImporter::importMessageStartEventSubscription))
```

From ZeebeImportService.builder