### PR TITLE
fix: cleanup unnecessary log

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -43,8 +43,6 @@ logging:
   level:
     root: ERROR
     io.zeebe: INFO
-    io.zeebe.monitor: DEBUG
-    com.hazelcast: WARN
 
 management:
   endpoint:


### PR DESCRIPTION
currently debugging log info also written  in log. removed default debug level log .