### PR TITLE
fix: message id generation created clashes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,12 @@
                 <version>${zeebe.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -56,12 +56,6 @@
                 <version>${zeebe.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
-                <exclusions>
-                    <exclusion>
-                        <groupId>commons-logging</groupId>
-                        <artifactId>commons-logging</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <dependency>
@@ -188,8 +182,8 @@
         </dependency>
 
         <dependency>
-           <groupId>io.micrometer</groupId>
-           <artifactId>micrometer-registry-prometheus</artifactId>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
 
         <dependency>

--- a/src/main/java/io/zeebe/monitor/repository/MessageSubscriptionRepository.java
+++ b/src/main/java/io/zeebe/monitor/repository/MessageSubscriptionRepository.java
@@ -16,8 +16,10 @@
 package io.zeebe.monitor.repository;
 
 import io.zeebe.monitor.entity.MessageSubscriptionEntity;
+
 import java.util.List;
 import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.CrudRepository;
@@ -26,19 +28,15 @@ import org.springframework.data.repository.PagingAndSortingRepository;
 public interface MessageSubscriptionRepository extends
         CrudRepository<MessageSubscriptionEntity, Long>, PagingAndSortingRepository<MessageSubscriptionEntity, Long> {
 
-  Page<MessageSubscriptionEntity> findByProcessInstanceKey(
-      long processInstanceKey, Pageable pageable);
+    Page<MessageSubscriptionEntity> findByProcessInstanceKey(long processInstanceKey, Pageable pageable);
 
-  long countByProcessInstanceKey(long processInstanceKey);
+    long countByProcessInstanceKey(long processInstanceKey);
 
-  Optional<MessageSubscriptionEntity> findByElementInstanceKeyAndMessageName(
-      long elementInstanceKey, String messageName);
+    Optional<MessageSubscriptionEntity> findByElementInstanceKeyAndMessageName(long elementInstanceKey, String messageName);
 
-  Optional<MessageSubscriptionEntity> findByProcessDefinitionKeyAndMessageName(
-      long processDefinitionKey, String messageName);
+    Optional<MessageSubscriptionEntity> findByProcessDefinitionKeyAndMessageName(long processDefinitionKey, String messageName);
 
-  List<MessageSubscriptionEntity> findByProcessDefinitionKeyAndProcessInstanceKeyIsNull(
-      long processDefinitionKey);
+    List<MessageSubscriptionEntity> findByProcessDefinitionKeyAndProcessInstanceKeyIsNull(long processDefinitionKey);
 
-  void deleteAllByProcessInstanceKey(long processInstanceKey);
+    void deleteAllByProcessInstanceKey(long processInstanceKey);
 }

--- a/src/main/java/io/zeebe/monitor/zeebe/ZeebeImportService.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/ZeebeImportService.java
@@ -19,76 +19,83 @@ import static io.zeebe.monitor.zeebe.util.ImportUtil.ifEvent;
 @Component
 public class ZeebeImportService {
 
-  @Autowired private ProcessAndElementImporter processAndElementImporter;
-  @Autowired private VariableImporter variableImporter;
-  @Autowired private JobImporter jobImporter;
-  @Autowired private IncidentImporter incidentImporter;
-  @Autowired private MessageImporter messageImporter;
-  @Autowired private MessageSubscriptionImporter messageSubscriptionImporter;
-  @Autowired private TimerImporter timerImporter;
-  @Autowired private ErrorImporter errorImporter;
+    @Autowired
+    private ProcessAndElementImporter processAndElementImporter;
+    @Autowired
+    private VariableImporter variableImporter;
+    @Autowired
+    private JobImporter jobImporter;
+    @Autowired
+    private IncidentImporter incidentImporter;
+    @Autowired
+    private MessageImporter messageImporter;
+    @Autowired
+    private MessageSubscriptionImporter messageSubscriptionImporter;
+    @Autowired
+    private TimerImporter timerImporter;
+    @Autowired
+    private ErrorImporter errorImporter;
 
-  @Autowired private HazelcastConfigRepository hazelcastConfigRepository;
+    @Autowired
+    private HazelcastConfigRepository hazelcastConfigRepository;
 
-  public ZeebeHazelcast importFrom(final HazelcastInstance hazelcast) {
+    public ZeebeHazelcast importFrom(final HazelcastInstance hazelcast) {
 
-    final var hazelcastConfig =
-        hazelcastConfigRepository
-            .findById("cfg")
-            .orElseGet(
-                () -> {
-                  final var config = new HazelcastConfig();
-                  config.setId("cfg");
-                  config.setSequence(-1);
-                  return config;
-                });
+        final var hazelcastConfig =
+                hazelcastConfigRepository
+                        .findById("cfg")
+                        .orElseGet(
+                                () -> {
+                                    final var config = new HazelcastConfig();
+                                    config.setId("cfg");
+                                    config.setSequence(-1);
+                                    return config;
+                                });
 
-    final var builder =
-        ZeebeHazelcast.newBuilder(hazelcast)
-            .addProcessListener(
-                record -> ifEvent(record, Schema.ProcessRecord::getMetadata, processAndElementImporter::importProcess))
-            .addProcessInstanceListener(
-                record ->
-                    ifEvent(
-                        record,
-                        Schema.ProcessInstanceRecord::getMetadata,
-                        processAndElementImporter::importProcessInstance))
-            .addIncidentListener(
-                record -> ifEvent(record, Schema.IncidentRecord::getMetadata, incidentImporter::importIncident))
-            .addJobListener(
-                record -> ifEvent(record, Schema.JobRecord::getMetadata, jobImporter::importJob))
-            .addVariableListener(
-                record -> ifEvent(record, Schema.VariableRecord::getMetadata, variableImporter::importVariable))
-            .addTimerListener(
-                record -> ifEvent(record, Schema.TimerRecord::getMetadata, timerImporter::importTimer))
-            .addMessageListener(
-                record -> ifEvent(record, Schema.MessageRecord::getMetadata, messageImporter::importMessage))
-            .addMessageSubscriptionListener(
-                record ->
-                    ifEvent(
-                        record,
-                        Schema.MessageSubscriptionRecord::getMetadata,
-                            messageSubscriptionImporter::importMessageSubscription))
-            .addMessageStartEventSubscriptionListener(
-                record ->
-                    ifEvent(
-                        record,
-                        Schema.MessageStartEventSubscriptionRecord::getMetadata,
-                            messageSubscriptionImporter::importMessageStartEventSubscription))
-            .addErrorListener(errorImporter::importError)
-            .postProcessListener(
-                sequence -> {
-                  hazelcastConfig.setSequence(sequence);
-                  hazelcastConfigRepository.save(hazelcastConfig);
-                });
+        final var builder =
+                ZeebeHazelcast.newBuilder(hazelcast)
+                        .addProcessListener(
+                                record -> ifEvent(record, Schema.ProcessRecord::getMetadata, processAndElementImporter::importProcess))
+                        .addProcessInstanceListener(
+                                record ->
+                                        ifEvent(
+                                                record,
+                                                Schema.ProcessInstanceRecord::getMetadata,
+                                                processAndElementImporter::importProcessInstance))
+                        .addIncidentListener(
+                                record -> ifEvent(record, Schema.IncidentRecord::getMetadata, incidentImporter::importIncident))
+                        .addJobListener(
+                                record -> ifEvent(record, Schema.JobRecord::getMetadata, jobImporter::importJob))
+                        .addVariableListener(
+                                record -> ifEvent(record, Schema.VariableRecord::getMetadata, variableImporter::importVariable))
+                        .addTimerListener(
+                                record -> ifEvent(record, Schema.TimerRecord::getMetadata, timerImporter::importTimer))
+                        .addMessageListener(
+                                record -> ifEvent(record, Schema.MessageRecord::getMetadata, messageImporter::importMessage))
+                        .addMessageSubscriptionListener(
+                                record ->
+                                        ifEvent(
+                                                record,
+                                                Schema.MessageSubscriptionRecord::getMetadata, messageSubscriptionImporter::importMessageSubscription))
+                        .addMessageStartEventSubscriptionListener(
+                                record ->
+                                        ifEvent(
+                                                record,
+                                                Schema.MessageStartEventSubscriptionRecord::getMetadata, messageSubscriptionImporter::importMessageStartEventSubscription))
+                        .addErrorListener(errorImporter::importError)
+                        .postProcessListener(
+                                sequence -> {
+                                    hazelcastConfig.setSequence(sequence);
+                                    hazelcastConfigRepository.save(hazelcastConfig);
+                                });
 
-    if (hazelcastConfig.getSequence() >= 0) {
-      builder.readFrom(hazelcastConfig.getSequence());
-    } else {
-      builder.readFromHead();
+        if (hazelcastConfig.getSequence() >= 0) {
+            builder.readFrom(hazelcastConfig.getSequence());
+        } else {
+            builder.readFromHead();
+        }
+
+        return builder.build();
     }
-
-    return builder.build();
-  }
 
 }

--- a/src/main/java/io/zeebe/monitor/zeebe/importers/MessageSubscriptionImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/importers/MessageSubscriptionImporter.java
@@ -13,64 +13,60 @@ import java.util.UUID;
 @Component
 public class MessageSubscriptionImporter {
 
-  @Autowired private MessageSubscriptionRepository messageSubscriptionRepository;
+    @Autowired
+    private MessageSubscriptionRepository messageSubscriptionRepository;
 
-  public void importMessageSubscription(final Schema.MessageSubscriptionRecord record) {
+    public void importMessageSubscription(final Schema.MessageSubscriptionRecord record) {
 
-    final MessageSubscriptionIntent intent =
-        MessageSubscriptionIntent.valueOf(record.getMetadata().getIntent());
-    final long timestamp = record.getMetadata().getTimestamp();
+        final MessageSubscriptionIntent intent = MessageSubscriptionIntent.valueOf(record.getMetadata().getIntent());
+        final long timestamp = record.getMetadata().getTimestamp();
 
-    final MessageSubscriptionEntity entity =
-        messageSubscriptionRepository
-            .findByElementInstanceKeyAndMessageName(
-                record.getElementInstanceKey(), record.getMessageName())
-            .orElseGet(
-                () -> {
-                  final MessageSubscriptionEntity newEntity = new MessageSubscriptionEntity();
-                  newEntity.setId(
-                      generateId()); // message subscription doesn't have a key - it is always '-1'
-                  newEntity.setElementInstanceKey(record.getElementInstanceKey());
-                  newEntity.setMessageName(record.getMessageName());
-                  newEntity.setCorrelationKey(record.getCorrelationKey());
-                  newEntity.setProcessInstanceKey(record.getProcessInstanceKey());
-                  return newEntity;
-                });
+        final MessageSubscriptionEntity entity =
+                messageSubscriptionRepository
+                        .findByElementInstanceKeyAndMessageName(record.getElementInstanceKey(), record.getMessageName())
+                        .orElseGet(
+                                () -> {
+                                    final MessageSubscriptionEntity newEntity = new MessageSubscriptionEntity();
+                                    // need to build a logical id since message subscription doesn't have a key - it is always '-1'
+                                    newEntity.setId(
+                                            record.getElementInstanceKey() + "-" + record.getMessageName() + "-" + record.getProcessInstanceKey());
+                                    newEntity.setElementInstanceKey(record.getElementInstanceKey());
+                                    newEntity.setMessageName(record.getMessageName());
+                                    newEntity.setCorrelationKey(record.getCorrelationKey());
+                                    newEntity.setProcessInstanceKey(record.getProcessInstanceKey());
+                                    return newEntity;
+                                });
 
-    entity.setState(intent.name().toLowerCase());
-    entity.setTimestamp(timestamp);
-    messageSubscriptionRepository.save(entity);
-  }
+        entity.setState(intent.name().toLowerCase());
+        entity.setTimestamp(timestamp);
+        messageSubscriptionRepository.save(entity);
+    }
 
-  public void importMessageStartEventSubscription(
-      final Schema.MessageStartEventSubscriptionRecord record) {
+    public void importMessageStartEventSubscription(
+            final Schema.MessageStartEventSubscriptionRecord record) {
 
-    final MessageStartEventSubscriptionIntent intent =
-        MessageStartEventSubscriptionIntent.valueOf(record.getMetadata().getIntent());
-    final long timestamp = record.getMetadata().getTimestamp();
+        final MessageStartEventSubscriptionIntent intent =
+                MessageStartEventSubscriptionIntent.valueOf(record.getMetadata().getIntent());
+        final long timestamp = record.getMetadata().getTimestamp();
 
-    final MessageSubscriptionEntity entity =
-        messageSubscriptionRepository
-            .findByProcessDefinitionKeyAndMessageName(
-                record.getProcessDefinitionKey(), record.getMessageName())
-            .orElseGet(
-                () -> {
-                  final MessageSubscriptionEntity newEntity = new MessageSubscriptionEntity();
-                  newEntity.setId(
-                      generateId()); // message subscription doesn't have a key - it is always '-1'
-                  newEntity.setMessageName(record.getMessageName());
-                  newEntity.setProcessDefinitionKey(record.getProcessDefinitionKey());
-                  newEntity.setTargetFlowNodeId(record.getStartEventId());
-                  return newEntity;
-                });
+        final MessageSubscriptionEntity entity =
+                messageSubscriptionRepository
+                        .findByProcessDefinitionKeyAndMessageName(
+                                record.getProcessDefinitionKey(), record.getMessageName())
+                        .orElseGet(
+                                () -> {
+                                    final MessageSubscriptionEntity newEntity = new MessageSubscriptionEntity();
+                                    // need to build a logical id since message subscription doesn't have a key - it is always '-1'
+                                    newEntity.setId(
+                                            record.getProcessDefinitionKey() + "-" + record.getMessageName() + "-" + record.getProcessInstanceKey());
+                                    newEntity.setMessageName(record.getMessageName());
+                                    newEntity.setProcessDefinitionKey(record.getProcessDefinitionKey());
+                                    newEntity.setTargetFlowNodeId(record.getStartEventId());
+                                    return newEntity;
+                                });
 
-    entity.setState(intent.name().toLowerCase());
-    entity.setTimestamp(timestamp);
-    messageSubscriptionRepository.save(entity);
-  }
-
-  private String generateId() {
-    return UUID.randomUUID().toString();
-  }
-
+        entity.setState(intent.name().toLowerCase());
+        entity.setTimestamp(timestamp);
+        messageSubscriptionRepository.save(entity);
+    }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -53,8 +53,9 @@ server:
 
 logging:
   level:
-    root: ERROR
+    root: INFO
     io.zeebe: INFO
+
 
 management:
   endpoint:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -53,9 +53,8 @@ server:
 
 logging:
   level:
-    root: INFO
+    root: ERROR
     io.zeebe: INFO
-
 
 management:
   endpoint:


### PR DESCRIPTION
Sorry for all the autoformatting.

The message subscription streams can sometimes process twice which results in things records being written twice to the DB. This is not a problem but there is a query that expects a single record to be returned, which of course can't happen when there are "duplicate" records.