### PR TITLE
fix: bump to java 21 and zeebe 8.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '17'
+          java-version: '21'
           cache: 'maven'
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots verify

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: '17'
+          java-version: '21'
           cache: 'maven'
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots verify
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: '17'
+          java-version: '21'
           cache: 'maven'
       - name: Build with Maven
         run: mvn -B package --file pom.xml -Dmaven.test.skip # Tests are already run

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk-alpine:17-jre
+FROM azul/zulu-openjdk-alpine:21-jre
 
 RUN apk update && \
     apk upgrade && \

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <zeebe.version>8.2.15</zeebe.version>
-        <version.zeebe.spring>8.2.4</version.zeebe.spring>
+        <zeebe.version>8.4.6</zeebe.version>
+        <version.zeebe.spring>8.4.2</version.zeebe.spring>
         <hazelcast.exporter.version>1.4.0</hazelcast.exporter.version>
 
         <kafka.version>3.6.0</kafka.version>
@@ -30,7 +30,7 @@
         <version.hazelcast>5.3.7</version.hazelcast>
 
         <!-- release parent settings -->
-        <version.java>17</version.java>
+        <version.java>21</version.java>
         <java.version>${version.java}</java.version>
 
         <maven.compiler.source>${java.version}</maven.compiler.source>


### PR DESCRIPTION
- Bumped Java and zeebe versions
- Bumped Java version in workflows
- Bumped Dockerfile base image
- Tested by running devenv and this zeebe-simple-monitor, then running vnoc-process-manager and checking that the bpmns are added

VNOC-9752

**Test Instructions:**
1. Run devenv ("normal" profile is enough)
2. Change profile to kafka https://github.com/elisapolystar/zeebe-simple-monitor/blob/main/src/main/resources/application.yaml#L39
3. After running, simple monitor is accessbile at http://localhost:8082