### PR TITLE
Revert "fix: make enum cols work"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,13 @@
             <classifier>jakarta</classifier>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/io.github.classgraph/classgraph -->
+        <dependency>
+            <groupId>io.github.classgraph</groupId>
+            <artifactId>classgraph</artifactId>
+            <version>4.8.172</version>
+        </dependency>
+
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
         <dependency>
             <groupId>com.querydsl</groupId>
             <artifactId>querydsl-apt</artifactId>
-            <version>5.1.0</version>
+            <version>5.0.0</version>
             <classifier>jakarta</classifier>
             <scope>provided</scope>
         </dependency>
@@ -202,15 +202,8 @@
         <dependency>
             <groupId>com.querydsl</groupId>
             <artifactId>querydsl-jpa</artifactId>
-            <version>5.1.0</version>
+            <version>5.0.0</version>
             <classifier>jakarta</classifier>
-        </dependency>
-
-        <!-- https://mvnrepository.com/artifact/io.github.classgraph/classgraph -->
-        <dependency>
-            <groupId>io.github.classgraph</groupId>
-            <artifactId>classgraph</artifactId>
-            <version>4.8.172</version>
         </dependency>
 
         <dependency>
@@ -229,12 +222,6 @@
             <!-- to be bundled into the docker file, for convenience, see issue #254 -->
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hibernate.orm</groupId>
-            <artifactId>hibernate-core</artifactId>
-            <version>6.5.0.Final</version>
         </dependency>
 
         <dependency>
@@ -537,11 +524,6 @@
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
-        </repository>
-        <repository>
-            <id>maven_central</id>
-            <name>Maven Central</name>
-            <url>https://repo.maven.apache.org/maven2/</url>
         </repository>
     </repositories>
 

--- a/src/main/java/io/zeebe/monitor/entity/ElementInstanceEntity.java
+++ b/src/main/java/io/zeebe/monitor/entity/ElementInstanceEntity.java
@@ -15,11 +15,9 @@
  */
 package io.zeebe.monitor.entity;
 
-import io.zeebe.monitor.model.BpmnElementType;
-import io.zeebe.monitor.model.IntentType;
+import io.zeebe.monitor.model.BPMNElementTypes;
+import io.zeebe.monitor.model.IntentTypes;
 import jakarta.persistence.*;
-import org.hibernate.annotations.JdbcType;
-import org.hibernate.dialect.PostgreSQLEnumJdbcType;
 
 @Entity(name = "ELEMENT_INSTANCE")
 @Table(indexes = {
@@ -42,12 +40,12 @@ public class ElementInstanceEntity {
     @Column(name = "KEY_")
     private long key;
 
+
     // For some reason, they didn't map this to the ProcessInstanceIntent class
     // (probably because it's for ProcessInstances)
-    @Column(name = "INTENT_", columnDefinition = "ei_intent")
+    @Column(name = "INTENT_")
     @Enumerated(EnumType.STRING)
-    @JdbcType(PostgreSQLEnumJdbcType.class)
-    private IntentType intent;
+    private IntentTypes intent;
 
     @Column(name = "PROCESS_INSTANCE_KEY_")
     private long processInstanceKey;
@@ -55,10 +53,9 @@ public class ElementInstanceEntity {
     @Column(name = "ELEMENT_ID_")
     private String elementId;
 
-    @Column(name = "BPMN_ELEMENT_TYPE_", columnDefinition = "ei_bpmn_element_type")
+    @Column(name = "BPMN_ELEMENT_TYPE_")
     @Enumerated(EnumType.STRING)
-    @JdbcType(PostgreSQLEnumJdbcType.class)
-    private BpmnElementType bpmnElementType;
+    private BPMNElementTypes bpmnElementType;
 
     @Column(name = "FLOW_SCOPE_KEY_")
     private long flowScopeKey;
@@ -100,10 +97,10 @@ public class ElementInstanceEntity {
     }
 
     public void setIntent(final String intent) {
-        this.intent = IntentType.valueOf(intent);
+        this.intent = IntentTypes.valueOf(intent);
     }
 
-    public void setIntent(final IntentType intent) {
+    public void setIntent(final IntentTypes intent) {
         this.intent = intent;
     }
 
@@ -168,11 +165,11 @@ public class ElementInstanceEntity {
         return bpmnElementType.name();
     }
 
-    public void setBpmnElementType(final BpmnElementType bpmnElementType) {
+    public void setBpmnElementType(final BPMNElementTypes bpmnElementType) {
         this.bpmnElementType = bpmnElementType;
     }
 
     public void setBpmnElementType(final String bpmnElementType) {
-        this.bpmnElementType = BpmnElementType.valueOf(bpmnElementType);
+        this.bpmnElementType = BPMNElementTypes.valueOf(bpmnElementType);
     }
 }

--- a/src/main/java/io/zeebe/monitor/model/BPMNElementTypes.java
+++ b/src/main/java/io/zeebe/monitor/model/BPMNElementTypes.java
@@ -1,6 +1,6 @@
 package io.zeebe.monitor.model;
 
-public enum BpmnElementType {
+public enum BPMNElementTypes {
     END_EVENT,
     START_EVENT,
     RECEIVE_TASK,

--- a/src/main/java/io/zeebe/monitor/model/IntentTypes.java
+++ b/src/main/java/io/zeebe/monitor/model/IntentTypes.java
@@ -2,7 +2,7 @@ package io.zeebe.monitor.model;
 
 // This was created by running DISTINCT on this column in a long-running
 // simple-monitor db install
-public enum IntentType {
+public enum IntentTypes {
     ELEMENT_ACTIVATING,
     SEQUENCE_FLOW_TAKEN,
     ELEMENT_COMPLETED,

--- a/src/main/java/io/zeebe/monitor/repository/ProcessRepository.java
+++ b/src/main/java/io/zeebe/monitor/repository/ProcessRepository.java
@@ -20,7 +20,6 @@ import io.zeebe.monitor.entity.ProcessEntity;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
@@ -36,7 +35,7 @@ public interface ProcessRepository extends
       value =
           "SELECT ELEMENT_ID_ AS elementId, COUNT(*) AS count "
               + "FROM ELEMENT_INSTANCE "
-              + "WHERE PROCESS_DEFINITION_KEY_ = :key and INTENT_::text in (:intents) and BPMN_ELEMENT_TYPE_::text not in (:excludeElementTypes)"
+              + "WHERE PROCESS_DEFINITION_KEY_ = :key and INTENT_ in (:intents) and BPMN_ELEMENT_TYPE_ not in (:excludeElementTypes)"
               + "GROUP BY ELEMENT_ID_")
   List<ElementInstanceStatistics> getElementInstanceStatisticsByKeyAndIntentIn(
       @Param("key") long key,

--- a/src/main/java/io/zeebe/monitor/rest/ProcessesViewController.java
+++ b/src/main/java/io/zeebe/monitor/rest/ProcessesViewController.java
@@ -1,7 +1,5 @@
 package io.zeebe.monitor.rest;
 
-import static io.zeebe.monitor.model.BpmnElementType.MULTI_INSTANCE_BODY;
-import static io.zeebe.monitor.model.IntentType.*;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -13,6 +11,7 @@ import io.camunda.zeebe.model.bpmn.instance.ServiceTask;
 import io.camunda.zeebe.model.bpmn.instance.TimerEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.zeebe.monitor.entity.ElementInstanceStatistics;
 import io.zeebe.monitor.entity.MessageSubscriptionEntity;
 import io.zeebe.monitor.entity.ProcessEntity;
@@ -47,11 +46,11 @@ import org.springframework.web.server.ResponseStatusException;
 @Controller
 public class ProcessesViewController extends AbstractViewController {
 
-  static final List<String> PROCESS_INSTANCE_ENTERED_INTENTS = List.of(ELEMENT_ACTIVATED.name());
+  static final List<String> PROCESS_INSTANCE_ENTERED_INTENTS = List.of("ELEMENT_ACTIVATED");
   static final List<String> PROCESS_INSTANCE_COMPLETED_INTENTS =
-      List.of(ELEMENT_COMPLETED.name(), ELEMENT_TERMINATED.name());
+      List.of("ELEMENT_COMPLETED", "ELEMENT_TERMINATED");
   static final List<String> EXCLUDE_ELEMENT_TYPES =
-      List.of(MULTI_INSTANCE_BODY.name());
+      List.of(BpmnElementType.MULTI_INSTANCE_BODY.name());
 
   @Autowired private ProcessRepository processRepository;
   @Autowired private ProcessInstanceRepository processInstanceRepository;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -23,7 +23,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
-      ddl-auto: none
+      ddl-auto: update
 
   mustache:
     prefix: classpath:/templates/

--- a/src/test/java/io/zeebe/monitor/zeebe/importers/ProcessAndElementImporterTest.java
+++ b/src/test/java/io/zeebe/monitor/zeebe/importers/ProcessAndElementImporterTest.java
@@ -3,11 +3,10 @@ package io.zeebe.monitor.zeebe.importers;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.zeebe.exporter.proto.Schema;
 import io.zeebe.monitor.entity.ElementInstanceEntity;
-import io.zeebe.monitor.model.BpmnElementType;
+import io.zeebe.monitor.model.BPMNElementTypes;
 import io.zeebe.monitor.repository.ElementInstanceRepository;
 import io.zeebe.monitor.repository.ZeebeRepositoryTest;
 import io.zeebe.monitor.zeebe.ZeebeNotificationService;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -20,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
     classes = {ProcessAndElementImporter.class,
         ZeebeNotificationService.class}
 )
-@Disabled("Broken with custom Postgres data types")
 public class ProcessAndElementImporterTest extends ZeebeRepositoryTest {
 
   @Autowired
@@ -55,7 +53,7 @@ public class ProcessAndElementImporterTest extends ZeebeRepositoryTest {
             .setPosition(333L)
             .setPartitionId(55555)
             .setIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED.name()))
-            .setBpmnElementType(BpmnElementType.PROCESS.name())
+            .setBpmnElementType(BPMNElementTypes.PROCESS.name())
         .build();
   }
 

--- a/src/test/resources/application-junittest.yaml
+++ b/src/test/resources/application-junittest.yaml
@@ -5,6 +5,3 @@ logging:
 spring:
   flyway:
     enabled: false
-  jpa:
-    hibernate:
-      ddl-auto: update

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -8,5 +8,5 @@
     <logger name="org.springframework.transaction" level="error" />
     <logger name="org.springframework.web" level="error" />
     <logger name="org.springframework.test" level="error" />
-    <logger name="org.hibernate" level="info" />
+    <logger name="org.hibernate" level="error" />
 </configuration>


### PR DESCRIPTION
Reverts elisapolystar/zeebe-simple-monitor#156

DB columns types are not updated correctly, causes exception in simple-monitor:
`Caused by: org.postgresql.util.PSQLException: ERROR: column "bpmn_element_type_" is of type ei_bpmn_element_type but expression is of type character varying
  Hint: You will need to rewrite or cast the expression.`