### PR TITLE
fix: stop all the race conditions

### DIFF
--- a/src/main/java/io/zeebe/monitor/zeebe/importers/IncidentImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/importers/IncidentImporter.java
@@ -4,45 +4,59 @@ import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.zeebe.exporter.proto.Schema;
 import io.zeebe.monitor.entity.IncidentEntity;
 import io.zeebe.monitor.repository.IncidentRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 
 @Component
 public class IncidentImporter {
 
-  @Autowired private IncidentRepository incidentRepository;
+    @Autowired
+    private IncidentRepository incidentRepository;
 
-  public void importIncident(final Schema.IncidentRecord record) {
+    private static final Logger LOG = LoggerFactory.getLogger(IncidentImporter.class);
 
-    final IncidentIntent intent = IncidentIntent.valueOf(record.getMetadata().getIntent());
-    final long key = record.getMetadata().getKey();
-    final long timestamp = record.getMetadata().getTimestamp();
+    public void importIncident(final Schema.IncidentRecord record) {
 
-    final IncidentEntity entity =
-        incidentRepository
-            .findById(key)
-            .orElseGet(
-                () -> {
-                  final IncidentEntity newEntity = new IncidentEntity();
-                  newEntity.setKey(key);
-                  newEntity.setBpmnProcessId(record.getBpmnProcessId());
-                  newEntity.setProcessDefinitionKey(record.getProcessDefinitionKey());
-                  newEntity.setProcessInstanceKey(record.getProcessInstanceKey());
-                  newEntity.setElementInstanceKey(record.getElementInstanceKey());
-                  newEntity.setJobKey(record.getJobKey());
-                  newEntity.setErrorType(record.getErrorType());
-                  newEntity.setErrorMessage(record.getErrorMessage());
-                  return newEntity;
-                });
+        final IncidentIntent intent = IncidentIntent.valueOf(record.getMetadata().getIntent());
+        final long key = record.getMetadata().getKey();
+        final long timestamp = record.getMetadata().getTimestamp();
 
-    if (intent == IncidentIntent.CREATED) {
-      entity.setCreated(timestamp);
-      incidentRepository.save(entity);
+        final IncidentEntity entity =
+                incidentRepository
+                        .findById(key)
+                        .orElseGet(
+                                () -> {
+                                    final IncidentEntity newEntity = new IncidentEntity();
+                                    newEntity.setKey(key);
+                                    newEntity.setBpmnProcessId(record.getBpmnProcessId());
+                                    newEntity.setProcessDefinitionKey(record.getProcessDefinitionKey());
+                                    newEntity.setProcessInstanceKey(record.getProcessInstanceKey());
+                                    newEntity.setElementInstanceKey(record.getElementInstanceKey());
+                                    newEntity.setJobKey(record.getJobKey());
+                                    newEntity.setErrorType(record.getErrorType());
+                                    newEntity.setErrorMessage(record.getErrorMessage());
+                                    return newEntity;
+                                });
 
-    } else if (intent == IncidentIntent.RESOLVED) {
-      entity.setResolved(timestamp);
-      incidentRepository.save(entity);
+        if (intent == IncidentIntent.CREATED) {
+            entity.setCreated(timestamp);
+            try {
+                incidentRepository.save(entity);
+            } catch (DataIntegrityViolationException e) {
+                LOG.warn("Attempted to save duplicate Incident with key {}", entity.getKey());
+            }
+
+        } else if (intent == IncidentIntent.RESOLVED) {
+            entity.setResolved(timestamp);
+            try {
+                incidentRepository.save(entity);
+            } catch (DataIntegrityViolationException e) {
+                LOG.warn("Attempted to save duplicate Incident with key {}", entity.getKey());
+            }
+        }
     }
-  }
 
 }

--- a/src/main/java/io/zeebe/monitor/zeebe/importers/JobImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/importers/JobImporter.java
@@ -4,38 +4,47 @@ import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.zeebe.exporter.proto.Schema;
 import io.zeebe.monitor.entity.JobEntity;
 import io.zeebe.monitor.repository.JobRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 
 @Component
 public class JobImporter {
 
-  @Autowired private JobRepository jobRepository;
+    @Autowired
+    private JobRepository jobRepository;
+    private static final Logger LOG = LoggerFactory.getLogger(JobImporter.class);
 
-  public void importJob(final Schema.JobRecord record) {
+    public void importJob(final Schema.JobRecord record) {
 
-    final JobIntent intent = JobIntent.valueOf(record.getMetadata().getIntent());
-    final long key = record.getMetadata().getKey();
-    final long timestamp = record.getMetadata().getTimestamp();
+        final JobIntent intent = JobIntent.valueOf(record.getMetadata().getIntent());
+        final long key = record.getMetadata().getKey();
+        final long timestamp = record.getMetadata().getTimestamp();
 
-    final JobEntity entity =
-        jobRepository
-            .findById(key)
-            .orElseGet(
-                () -> {
-                  final JobEntity newEntity = new JobEntity();
-                  newEntity.setKey(key);
-                  newEntity.setProcessInstanceKey(record.getProcessInstanceKey());
-                  newEntity.setElementInstanceKey(record.getElementInstanceKey());
-                  newEntity.setJobType(record.getType());
-                  return newEntity;
-                });
+        final JobEntity entity =
+                jobRepository
+                        .findById(key)
+                        .orElseGet(
+                                () -> {
+                                    final JobEntity newEntity = new JobEntity();
+                                    newEntity.setKey(key);
+                                    newEntity.setProcessInstanceKey(record.getProcessInstanceKey());
+                                    newEntity.setElementInstanceKey(record.getElementInstanceKey());
+                                    newEntity.setJobType(record.getType());
+                                    return newEntity;
+                                });
 
-    entity.setState(intent.name().toLowerCase());
-    entity.setTimestamp(timestamp);
-    entity.setWorker(record.getWorker());
-    entity.setRetries(record.getRetries());
-    jobRepository.save(entity);
-  }
+        entity.setState(intent.name().toLowerCase());
+        entity.setTimestamp(timestamp);
+        entity.setWorker(record.getWorker());
+        entity.setRetries(record.getRetries());
+        try {
+            jobRepository.save(entity);
+        } catch (DataIntegrityViolationException e) {
+            LOG.warn("Attempted to save duplicate Job with key {}", entity.getKey());
+        }
+    }
 
 }

--- a/src/main/java/io/zeebe/monitor/zeebe/importers/MessageImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/importers/MessageImporter.java
@@ -4,36 +4,46 @@ import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.zeebe.exporter.proto.Schema;
 import io.zeebe.monitor.entity.MessageEntity;
 import io.zeebe.monitor.repository.MessageRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 
 @Component
 public class MessageImporter {
 
-  @Autowired private MessageRepository messageRepository;
+    @Autowired
+    private MessageRepository messageRepository;
 
-  public void importMessage(final Schema.MessageRecord record) {
+    private static final Logger LOG = LoggerFactory.getLogger(MessageImporter.class);
 
-    final MessageIntent intent = MessageIntent.valueOf(record.getMetadata().getIntent());
-    final long key = record.getMetadata().getKey();
-    final long timestamp = record.getMetadata().getTimestamp();
+    public void importMessage(final Schema.MessageRecord record) {
 
-    final MessageEntity entity =
-        messageRepository
-            .findById(key)
-            .orElseGet(
-                () -> {
-                  final MessageEntity newEntity = new MessageEntity();
-                  newEntity.setKey(key);
-                  newEntity.setName(record.getName());
-                  newEntity.setCorrelationKey(record.getCorrelationKey());
-                  newEntity.setMessageId(record.getMessageId());
-                  newEntity.setPayload(record.getVariables().toString());
-                  return newEntity;
-                });
+        final MessageIntent intent = MessageIntent.valueOf(record.getMetadata().getIntent());
+        final long key = record.getMetadata().getKey();
+        final long timestamp = record.getMetadata().getTimestamp();
 
-    entity.setState(intent.name().toLowerCase());
-    entity.setTimestamp(timestamp);
-    messageRepository.save(entity);
-  }
+        final MessageEntity entity =
+                messageRepository
+                        .findById(key)
+                        .orElseGet(
+                                () -> {
+                                    final MessageEntity newEntity = new MessageEntity();
+                                    newEntity.setKey(key);
+                                    newEntity.setName(record.getName());
+                                    newEntity.setCorrelationKey(record.getCorrelationKey());
+                                    newEntity.setMessageId(record.getMessageId());
+                                    newEntity.setPayload(record.getVariables().toString());
+                                    return newEntity;
+                                });
+
+        entity.setState(intent.name().toLowerCase());
+        entity.setTimestamp(timestamp);
+        try {
+            messageRepository.save(entity);
+        } catch (DataIntegrityViolationException e) {
+            LOG.warn("Attempted to save duplicate Message with key {}", entity.getKey());
+        }
+    }
 }

--- a/src/main/java/io/zeebe/monitor/zeebe/importers/MessageSubscriptionImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/importers/MessageSubscriptionImporter.java
@@ -5,13 +5,16 @@ import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.zeebe.exporter.proto.Schema;
 import io.zeebe.monitor.entity.MessageSubscriptionEntity;
 import io.zeebe.monitor.repository.MessageSubscriptionRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
-
-import java.util.UUID;
 
 @Component
 public class MessageSubscriptionImporter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MessageImporter.class);
 
     @Autowired
     private MessageSubscriptionRepository messageSubscriptionRepository;
@@ -39,7 +42,11 @@ public class MessageSubscriptionImporter {
 
         entity.setState(intent.name().toLowerCase());
         entity.setTimestamp(timestamp);
-        messageSubscriptionRepository.save(entity);
+        try {
+            messageSubscriptionRepository.save(entity);
+        } catch (DataIntegrityViolationException e) {
+            LOG.warn("Attempted to save duplicate MessageSubscription with id {}", entity.getId());
+        }
     }
 
     public void importMessageStartEventSubscription(

--- a/src/main/java/io/zeebe/monitor/zeebe/importers/TimerImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/importers/TimerImporter.java
@@ -4,43 +4,52 @@ import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.zeebe.exporter.proto.Schema;
 import io.zeebe.monitor.entity.TimerEntity;
 import io.zeebe.monitor.repository.TimerRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 
 @Component
 public class TimerImporter {
 
-  @Autowired private TimerRepository timerRepository;
+    private static final Logger LOG = LoggerFactory.getLogger(TimerImporter.class);
+    @Autowired
+    private TimerRepository timerRepository;
 
-  public void importTimer(final Schema.TimerRecord record) {
+    public void importTimer(final Schema.TimerRecord record) {
 
-    final TimerIntent intent = TimerIntent.valueOf(record.getMetadata().getIntent());
-    final long key = record.getMetadata().getKey();
-    final long timestamp = record.getMetadata().getTimestamp();
+        final TimerIntent intent = TimerIntent.valueOf(record.getMetadata().getIntent());
+        final long key = record.getMetadata().getKey();
+        final long timestamp = record.getMetadata().getTimestamp();
 
-    final TimerEntity entity =
-        timerRepository
-            .findById(key)
-            .orElseGet(
-                () -> {
-                  final TimerEntity newEntity = new TimerEntity();
-                  newEntity.setKey(key);
-                  newEntity.setProcessDefinitionKey(record.getProcessDefinitionKey());
-                  newEntity.setTargetElementId(record.getTargetElementId());
-                  newEntity.setDueDate(record.getDueDate());
-                  newEntity.setRepetitions(record.getRepetitions());
+        final TimerEntity entity =
+                timerRepository
+                        .findById(key)
+                        .orElseGet(
+                                () -> {
+                                    final TimerEntity newEntity = new TimerEntity();
+                                    newEntity.setKey(key);
+                                    newEntity.setProcessDefinitionKey(record.getProcessDefinitionKey());
+                                    newEntity.setTargetElementId(record.getTargetElementId());
+                                    newEntity.setDueDate(record.getDueDate());
+                                    newEntity.setRepetitions(record.getRepetitions());
 
-                  if (record.getProcessInstanceKey() > 0) {
-                    newEntity.setProcessInstanceKey(record.getProcessInstanceKey());
-                    newEntity.setElementInstanceKey(record.getElementInstanceKey());
-                  }
+                                    if (record.getProcessInstanceKey() > 0) {
+                                        newEntity.setProcessInstanceKey(record.getProcessInstanceKey());
+                                        newEntity.setElementInstanceKey(record.getElementInstanceKey());
+                                    }
 
-                  return newEntity;
-                });
+                                    return newEntity;
+                                });
 
-    entity.setState(intent.name().toLowerCase());
-    entity.setTimestamp(timestamp);
-    timerRepository.save(entity);
-  }
+        entity.setState(intent.name().toLowerCase());
+        entity.setTimestamp(timestamp);
+        try {
+            timerRepository.save(entity);
+        } catch (DataIntegrityViolationException e) {
+            LOG.warn("Attempted to save duplicate Timer with key {}", entity.getKey());
+        }
+    }
 
 }

--- a/src/main/java/io/zeebe/monitor/zeebe/importers/VariableImporter.java
+++ b/src/main/java/io/zeebe/monitor/zeebe/importers/VariableImporter.java
@@ -12,28 +12,28 @@ import org.springframework.stereotype.Component;
 @Component
 public class VariableImporter {
 
-  private static final Logger LOG = LoggerFactory.getLogger(ProcessAndElementImporter.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ProcessAndElementImporter.class);
 
-  @Autowired
-  private VariableRepository variableRepository;
+    @Autowired
+    private VariableRepository variableRepository;
 
-  public void importVariable(final Schema.VariableRecord record) {
-    final VariableEntity newVariable = new VariableEntity();
-    newVariable.setPosition(record.getMetadata().getPosition());
-    newVariable.setPartitionId(record.getMetadata().getPartitionId());
-    if (!variableRepository.existsById(newVariable.getGeneratedIdentifier())) {
-      newVariable.setTimestamp(record.getMetadata().getTimestamp());
-      newVariable.setProcessInstanceKey(record.getProcessInstanceKey());
-      newVariable.setName(record.getName());
-      newVariable.setValue(record.getValue());
-      newVariable.setScopeKey(record.getScopeKey());
-      newVariable.setState(record.getMetadata().getIntent().toLowerCase());
-      try {
-        variableRepository.save(newVariable);
-      } catch (DataIntegrityViolationException e){
-        LOG.warn("Attempted to save duplicate Element Instance with id {}", newVariable.getGeneratedIdentifier());
-      }
+    public void importVariable(final Schema.VariableRecord record) {
+        final VariableEntity newVariable = new VariableEntity();
+        newVariable.setPosition(record.getMetadata().getPosition());
+        newVariable.setPartitionId(record.getMetadata().getPartitionId());
+        if (!variableRepository.existsById(newVariable.getGeneratedIdentifier())) {
+            newVariable.setTimestamp(record.getMetadata().getTimestamp());
+            newVariable.setProcessInstanceKey(record.getProcessInstanceKey());
+            newVariable.setName(record.getName());
+            newVariable.setValue(record.getValue());
+            newVariable.setScopeKey(record.getScopeKey());
+            newVariable.setState(record.getMetadata().getIntent().toLowerCase());
+            try {
+                variableRepository.save(newVariable);
+            } catch (DataIntegrityViolationException e) {
+                LOG.warn("Attempted to save duplicate Element Instance with id {}", newVariable.getGeneratedIdentifier());
+            }
+        }
     }
-  }
 
 }


### PR DESCRIPTION
This adds the remaining checks to stop race conditions causing deadlocks when ingesting records (it's a bit clumsy but it'll do).

It also makes sure that process's will be saved no MATTER the partition they come from because that was a silly idea from original implementer.