### PR TITLE
fix: use artifact to pass the tag

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,7 +4,6 @@ on:
   workflow_run:
     workflows: [Main]
     types: [completed]
-  workflow_dispatch: { }
 
 env:
   REGISTRY: ghcr.io
@@ -54,22 +53,39 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Download the tarball
+
+      - name: Download Tag Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: tag_name
+
+      - name: Read Tag
+        id: read-tag
+        run: |
+          tag=$(cat tag_name.txt)
+          echo "tag_name=$tag" >> $GITHUB_ENV
+
+      - name: Download Tarball Artifact
         uses: actions/download-artifact@v4
         with:
           name: zeebe-simple-monitor.tgz
+
       - name: Create directory to extract to the tarball
         run: mkdir -p zeebe-simple-monitor
+
       - name: Extract tarball
         run: tar -xvzf zeebe-simple-monitor.tgz
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
@@ -78,10 +94,11 @@ jobs:
           flavor: |
             latest=false
           tags: |
-            type=semver,pattern={{version}}
+            type=semver,pattern={{version}},value=${{ env.tag_name }}
           labels: |
             org.opencontainers.image.authors=polystar/vnoc
             org.opencontainers.image.vendor=Elisa
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -54,6 +54,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: List Git Tags
+        run: git tag --list
       - name: Download the tarball
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -54,8 +54,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: List Git Tags
-        run: git tag --list
       - name: Download the tarball
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,6 +23,7 @@ jobs:
         run: |
           last_tag=$(git describe --tags $(git rev-list --tags --max-count=1))
           next_tag="${last_tag%.*}.$((${last_tag##*.}+1))"
+          echo "$next_tag" > tag_name.txt
           echo "tag_name=$next_tag" >> $GITHUB_ENV
 
       - name: Create Tag
@@ -48,3 +49,9 @@ jobs:
               tag_name: "${{ env.tag_name }}",
               generate_release_notes: true
             });
+
+      - name: Upload Tag as Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tag_name
+          path: tag_name.txt


### PR DESCRIPTION
https://github.com/docker/metadata-action?tab=readme-ov-file#typesemver

Seems like the tag is part of the push and release event context by default, and is missing for the `workflow_run` events. Tag can be passed as an artifact from the main workflow.