### PR TITLE
fix: add missing INTERMEDIATE_THROW_EVENT type

### DIFF
--- a/src/main/java/io/zeebe/monitor/model/BpmnElementType.java
+++ b/src/main/java/io/zeebe/monitor/model/BpmnElementType.java
@@ -15,4 +15,5 @@ public enum BpmnElementType {
     EVENT_BASED_GATEWAY,
     SUB_PROCESS,
     SEQUENCE_FLOW,
+    INTERMEDIATE_THROW_EVENT
 }

--- a/src/main/resources/db/migration/postgresql/V4__element_type_add_int_throw_event.sql
+++ b/src/main/resources/db/migration/postgresql/V4__element_type_add_int_throw_event.sql
@@ -1,0 +1,2 @@
+ALTER TYPE public.ei_bpmn_element_type ADD VALUE 'INTERMEDIATE_THROW_EVENT';
+


### PR DESCRIPTION
Using some 'new' Zeebe features has revealed we were missing a BPMNElementType